### PR TITLE
Add variants and format shipping date to Int std

### DIFF
--- a/src/Scrape.php
+++ b/src/Scrape.php
@@ -10,16 +10,22 @@ class Scrape
     public function run(): void
     {
         $initial_page = ScrapeHelper::fetchDocument('https://www.magpiehq.com/developer-challenge/smartphones');
-        $page1 = ScrapeHelper::craw_page_products($initial_page);
+        $page1 = ScrapeHelper::extract_page_products($initial_page);
         $initial_page->filter('#pages div a')->each(function($link, $i){
             $url = 'https://www.magpiehq.com/developer-challenge'.str_replace('..','',$link->attr('href'));
             if($i !== 0){
                 $page_data = ScrapeHelper::fetchDocument($url);
-                $this->products = array_merge($this->products, ScrapeHelper::craw_page_products($page_data));
+                $this->products = array_merge($this->products, ScrapeHelper::extract_page_products($page_data));
             }
         });
         $this->products = array_merge($this->products, $page1);
-        $data = array_unique($this->products, SORT_REGULAR);
+        $merged_variants = [];
+        foreach ($this->products as $dataset) {
+            foreach ($dataset as $data) {
+                $merged_variants[] = $data;
+            }
+        };
+        $data = array_unique($merged_variants, SORT_REGULAR);
         file_put_contents('output.json', str_replace('\\', '', json_encode($data)));
     }
 }

--- a/src/ScrapeHelper.php
+++ b/src/ScrapeHelper.php
@@ -18,21 +18,34 @@ class ScrapeHelper
         return substr($text, -2) == 'mb' ? substr($text, 0, strlen($text) - 2) : floatval(substr($text, 0, strlen($text) - 2)) * 1000;
     }
 
-    public static function craw_page_products($html_data): array{
-        return $html_data->filter('div.bg-white.p-4.rounded-md')->each(function($node, $i){
-            $availability = str_replace('Availability: ', '', $node->filter('div.my-4.text-sm.block.text-center')->text());
+    public static function color_variants($product_node){
+        
+        return $product_node->filter('div.flex-wrap.justify-center.-mx-2 .px-2')->each(function($node) use ($product_node){
+            // global $availability;
+            // global ;
+            $date_string = trim(str_replace([
+                'Available', 'Delivery', 'on', 'from', 'by', 
+                "Free Shipping", "Availability: Out of Stock",
+                "Free Delivery ", "Delivers ", "Unavailable for delivery"
+            ], '', $product_node->filter('div.my-4.text-sm.block.text-center')->last()->text()));
             return [
-                "title" => $node->filter('.product-name')->text(),
-                "price" => floatval((str_replace('£', '', $node->filter('div.my-8.block.text-center.text-lg')->text()))),
-                "imageUrl" => 'https://www.magpiehq.com/developer-challenge/images'.str_replace('..', '',$node->filter('img')->attr('src')),
-                "CapacityMB" => ScrapeHelper::to_mb($node->filter('.product-capacity')->text()),
+                "title" => $product_node->filter('.product-name')->text(),
+                "price" => floatval((str_replace('£', '', $product_node->filter('div.my-8.block.text-center.text-lg')->text()))),
+                "imageUrl" => 'https://www.magpiehq.com/developer-challenge/images'.str_replace('..', '',$product_node->filter('img')->attr('src')),
+                "CapacityMB" => ScrapeHelper::to_mb($product_node->filter('.product-capacity')->text()),
                 "color" => $node->filter('.rounded-full')->attr('data-colour'),
-                "availabilityText" => $availability,
-                "isAvailable" => substr(strtolower(str_replace(' ', '', $availability)),0, 2) == 'in' ? true : false,
-                "shippingText" => $node->filter('div.my-4.text-sm.block.text-center')->first()->text(),
-                "shippingDate" => $node->filter('div.my-4.text-sm.block.text-center')->last()->text(),
-
+                "availabilityText" => str_replace('Availability: ', '', $product_node->filter('div.my-4.text-sm.block.text-center')->text()),
+                "isAvailable" => substr(strtolower(str_replace(' ', '', str_replace('Availability: ', '', $product_node->filter('div.my-4.text-sm.block.text-center')->text()))),0, 2) == 'in' ? true : false,
+                "shippingText" => $product_node->filter('div.my-4.text-sm.block.text-center')->first()->text(),
+                "shippingDate" => strlen(strtotime($date_string)) > 0 ? date('Y-m-d', strtotime($date_string)) : $date_string,
+    
             ];
+        });
+    }
+
+    public static function extract_page_products($html_data): array{
+        return $html_data->filter('div.bg-white.p-4.rounded-md')->each(function($node, $i){
+            return ScrapeHelper::color_variants($node);
         });
     }
 }


### PR DESCRIPTION
## Variants
In this Crawler functionality update;
- Rename `craw_page_products` method to `extract_page_products`
- Fix the Shipping date (Format to `YY-MM-DD`) and leave blank where no shipping date has been provided
- Include all color variants as separate products